### PR TITLE
Milestone 3 - Friendship v2: Improve Performance of Friendship

### DIFF
--- a/app/controllers/friendships_controller.rb
+++ b/app/controllers/friendships_controller.rb
@@ -13,7 +13,7 @@ class FriendshipsController < ApplicationController
     if @reverse_friendship
       redirect_to friendships_path, alert: 'You already have an incoming request from this user.'
     else
-      @friendship = current_user.friendships.build(friend_id: params[:friend_id], confirmed: false)
+      @friendship = current_user.sent_requests.build(friend_id: params[:friend_id], confirmed: false)
       if @friendship.save
         redirect_to user_path(id: params[:friend_id]), notice: 'Friend request sent.'
       else
@@ -36,7 +36,16 @@ class FriendshipsController < ApplicationController
   end
 
   def destroy
-    Friendship.find(params[:id]).destroy
-    redirect_to friendships_path, notice: 'Friend request canceled/rejected/removed'
+    @friendship = Friendship.find(params[:id])
+    if current_user.sent_invite?(@friendship.friend)
+      @friendship.destroy
+      redirect_to friendships_path, notice: 'Friendship request canceled.'
+    elsif current_user.incoming_invite?(@friendship.user)
+      @friendship.destroy
+      redirect_to friendships_path, notice: 'Friend request rejected.'
+    else
+      @friendship.destroy
+      redirect_to friendships_path, notice: 'Friend removed.'
+    end
   end
 end

--- a/app/controllers/friendships_controller.rb
+++ b/app/controllers/friendships_controller.rb
@@ -20,7 +20,6 @@ class FriendshipsController < ApplicationController
         redirect_to users_path, alert: 'Request not sent. Something is wrong!'
       end
     end
-
   end
 
   def update
@@ -37,14 +36,12 @@ class FriendshipsController < ApplicationController
 
   def destroy
     @friendship = Friendship.find(params[:id])
+    @friendship.destroy
     if current_user.sent_invite?(@friendship.friend)
-      @friendship.destroy
       redirect_to friendships_path, notice: 'Friendship request canceled.'
     elsif current_user.incoming_invite?(@friendship.user)
-      @friendship.destroy
       redirect_to friendships_path, notice: 'Friend request rejected.'
     else
-      @friendship.destroy
       redirect_to friendships_path, notice: 'Friend removed.'
     end
   end

--- a/app/controllers/friendships_controller.rb
+++ b/app/controllers/friendships_controller.rb
@@ -2,7 +2,7 @@ class FriendshipsController < ApplicationController
   before_action :authenticate_user!
 
   def index
-    @confirmed_friends = current_user.friends
+    @confirmed_friendships = current_user.confirmed_friendships
     @sent_requests = current_user.sent_requests
     @incoming_requests = current_user.incoming_requests
   end
@@ -13,7 +13,7 @@ class FriendshipsController < ApplicationController
     if @reverse_friendship
       redirect_to friendships_path, alert: 'You already have an incoming request from this user.'
     else
-      @friendship = current_user.friendships.build(friend_id: params[:friend_id], confirmed: nil)
+      @friendship = current_user.friendships.build(friend_id: params[:friend_id], confirmed: false)
       if @friendship.save
         redirect_to user_path(id: params[:friend_id]), notice: 'Friend request sent.'
       else

--- a/app/controllers/friendships_controller.rb
+++ b/app/controllers/friendships_controller.rb
@@ -8,15 +8,19 @@ class FriendshipsController < ApplicationController
   end
 
   def create
-    # byebug
     @users = User.all
-    @friendship = current_user.friendships.build(friend_id: params[:friend_id], confirmed: false)
-
-    if @friendship.save
-      redirect_to user_path(id: params[:friend_id]), notice: 'Friend request sent.'
+    @reverse_friendship = Friendship.find_by(user_id: params[:friend_id], friend_id: current_user.id)
+    if @reverse_friendship
+      redirect_to friendships_path, alert: 'You already have an incoming request from this user.'
     else
-      redirect_to users_path, error: 'Request not sent. Something is wrong!'
+      @friendship = current_user.friendships.build(friend_id: params[:friend_id], confirmed: nil)
+      if @friendship.save
+        redirect_to user_path(id: params[:friend_id]), notice: 'Friend request sent.'
+      else
+        redirect_to users_path, alert: 'Request not sent. Something is wrong!'
+      end
     end
+
   end
 
   def update

--- a/app/helpers/friendships_helper.rb
+++ b/app/helpers/friendships_helper.rb
@@ -25,7 +25,7 @@ module FriendshipsHelper
       button_tag 'You', type: 'hidden', disabled: true, class: 'btn btn-secondary'
     else
       button_to 'Invite Friend',
-                { action: 'create', controller: 'friendships', friend_id: other_user .id },
+                { action: 'create', controller: 'friendships', friend_id: other_user.id },
                 method: :post, type: 'button', class: 'btn btn-secondary'
     end
   end

--- a/app/helpers/friendships_helper.rb
+++ b/app/helpers/friendships_helper.rb
@@ -12,14 +12,14 @@ module FriendshipsHelper
   end
 
   def first_friendship_button(other_user)
-    if current_user.sent_invite(other_user)
+    if current_user.sent_invite?(other_user)
       button_tag 'Invite Sent', type: 'button', disabled: true, class: 'btn btn-secondary'
-    elsif current_user.incoming_invite(other_user)
+    elsif current_user.incoming_invite?(other_user)
       button_to 'Accept Friend',
                 { action: 'update', controller: 'friendships',
-                  id: current_user.incoming_invite(other_user).id },
+                  id: current_user.incoming_invite?(other_user).id },
                 method: :put, type: 'button', class: 'btn btn-secondary'
-    elsif current_user.friend?(other_user)
+    elsif current_user.friendship_with?(other_user)
       button_tag 'You\'re Friends', type: 'hidden', disabled: true, class: 'btn btn-secondary'
     elsif current_user == other_user
       button_tag 'You', type: 'hidden', disabled: true, class: 'btn btn-secondary'
@@ -31,22 +31,22 @@ module FriendshipsHelper
   end
 
   def second_friendship_button(other_user)
-    if current_user.sent_invite(other_user)
+    if current_user.sent_invite?(other_user)
       button_to 'Cancel Invite',
                 { action: 'destroy', controller: 'friendships',
-                  id: current_user.sent_invite(other_user).id },
+                  id: current_user.sent_invite?(other_user).id },
                 method: :delete, data: { confirm: 'Are you sure?' },
                 type: 'button', class: 'btn btn-secondary'
-    elsif current_user.incoming_invite(other_user)
+    elsif current_user.incoming_invite?(other_user)
       button_to 'Reject Friend',
                 { action: 'destroy', controller: 'friendships',
-                  id: current_user.incoming_invite(other_user).id },
+                  id: current_user.incoming_invite?(other_user).id },
                 method: :delete, data: { confirm: 'Are you sure?' },
                 type: 'button', class: 'btn btn-secondary'
-    elsif current_user.friend?(other_user)
+    elsif current_user.friendship_with?(other_user)
       button_to 'Remove Friend',
                 { action: 'destroy', controller: 'friendships',
-                  id: current_user.friend?(other_user).id },
+                  id: current_user.friendship_with?(other_user).id },
                 method: :delete, data: { confirm: 'Are you sure?' },
                 type: 'button', class: 'btn btn-secondary'
     end

--- a/app/models/friendship.rb
+++ b/app/models/friendship.rb
@@ -7,10 +7,19 @@ class Friendship < ApplicationRecord
   belongs_to :friend, class_name: 'User'
 
   after_update :save_reverse_confirmed
+  after_destroy :destroy_reverse_friendship, if: :reverse_friendship_exists?
 
   private
 
   def save_reverse_confirmed
     Friendship.create(user_id: friend_id, friend_id: user_id, confirmed: true)
+  end
+
+  def destroy_reverse_friendship
+    Friendship.find_by(user_id: friend_id, friend_id: user_id).destroy
+  end
+
+  def reverse_friendship_exists?
+    true if Friendship.find_by(user_id: friend_id, friend_id: user_id)
   end
 end

--- a/app/models/friendship.rb
+++ b/app/models/friendship.rb
@@ -5,4 +5,12 @@ class Friendship < ApplicationRecord
 
   belongs_to :user
   belongs_to :friend, class_name: 'User'
+
+  after_update :save_reverse_confirmed
+
+  private
+
+  def save_reverse_confirmed
+    Friendship.create(user_id: friend_id, friend_id: user_id, confirmed: true)
+  end
 end

--- a/app/models/friendship.rb
+++ b/app/models/friendship.rb
@@ -6,20 +6,20 @@ class Friendship < ApplicationRecord
   belongs_to :user
   belongs_to :friend, class_name: 'User'
 
-  after_update :save_reverse_confirmed
+  after_update :create_reverse_confirmed
   after_destroy :destroy_reverse_friendship, if: :reverse_friendship_exists?
 
   private
 
-  def save_reverse_confirmed
+  def create_reverse_confirmed
     Friendship.create(user_id: friend_id, friend_id: user_id, confirmed: true)
   end
 
   def destroy_reverse_friendship
-    Friendship.find_by(user_id: friend_id, friend_id: user_id).destroy
+    Friendship.find_by(user_id: friend_id, friend_id: user_id, confirmed: true).destroy
   end
 
   def reverse_friendship_exists?
-    true if Friendship.find_by(user_id: friend_id, friend_id: user_id)
+    true if Friendship.find_by(user_id: friend_id, friend_id: user_id, confirmed: true)
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -6,43 +6,40 @@ class User < ApplicationRecord
 
   validates :name, presence: true, length: { maximum: 20 }
 
-  has_many :friendships
-  has_many :sent_requests, -> { where confirmed: false }, through: :friendships, source: :friend
-  has_many :inverse_friendships, class_name: 'Friendship', foreign_key: 'friend_id'
-  has_many :incoming_requests, -> { where confirmed: false }, through: :friendships, source: :friend
+  # has_many :friendships
+  has_many :sent_requests, -> { where confirmed: false }, class_name: 'Friendship', foreign_key: 'friend_id'
+  has_many :incoming_requests, -> { where confirmed: false }, class_name: 'Friendship', foreign_key: 'friend_id'
+  has_many :confirmed_friendships, -> { where confirmed: true }, class_name: 'Friendship', foreign_key: 'friend_id'
 
   has_many :posts
   has_many :comments, dependent: :destroy
   has_many :likes, dependent: :destroy
 
-  def reverse_exists?
-    true if Friendship.find(user_id: friend_id, friend_id: user_id)
-  end
 
-  def friends
-    friends_array = friendships.map { |friendship| friendship.friend if friendship.confirmed }
-    friends_array += inverse_friendships.map { |friendship| friendship.user if friendship.confirmed }
-    friends_array.compact
-  end
+  # def friends
+  #   friends_array = friendships.map { |friendship| friendship.friend if friendship.confirmed }
+  #   friends_array += inverse_friendships.map { |friendship| friendship.user if friendship.confirmed }
+  #   friends_array.compact
+  # end
 
-  def sent_requests
-    friendships.map { |friendship| friendship unless friendship.confirmed }.compact
-  end
+  # def sent_requests
+  #   friendships.map { |friendship| friendship unless friendship.confirmed }.compact
+  # end
 
-  def incoming_requests
-    inverse_friendships.map { |friendship| friendship unless friendship.confirmed }.compact
-  end
+  # def incoming_requests
+  #   inverse_friendships.map { |friendship| friendship unless friendship.confirmed }.compact
+  # end
 
-  def friend?(user)
-    friendships.find { |friendship| friendship.friend == user if friendship.confirmed } ||
-      inverse_friendships.find { |friendship| friendship.user == user if friendship.confirmed }
-  end
+  # def friend?(user)
+  #   friendships.find { |friendship| friendship.friend == user if friendship.confirmed } ||
+  #     inverse_friendships.find { |friendship| friendship.user == user if friendship.confirmed }
+  # end
 
-  def sent_invite(user)
-    friendships.find { |friendship| friendship.friend == user unless friendship.confirmed }
-  end
+  # def sent_invite(user)
+  #   friendships.find { |friendship| friendship.friend == user unless friendship.confirmed }
+  # end
 
-  def incoming_invite(user)
-    inverse_friendships.find { |friendship| friendship.user == user unless friendship.confirmed }
-  end
+  # def incoming_invite(user)
+  #   inverse_friendships.find { |friendship| friendship.user == user unless friendship.confirmed }
+  # end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -7,10 +7,17 @@ class User < ApplicationRecord
   validates :name, presence: true, length: { maximum: 20 }
 
   has_many :friendships
+  has_many :sent_requests, -> { where confirmed: false }, through: :friendships, source: :friend
   has_many :inverse_friendships, class_name: 'Friendship', foreign_key: 'friend_id'
+  has_many :incoming_requests, -> { where confirmed: false }, through: :friendships, source: :friend
+
   has_many :posts
   has_many :comments, dependent: :destroy
   has_many :likes, dependent: :destroy
+
+  def reverse_exists?
+    true if Friendship.find(user_id: friend_id, friend_id: user_id)
+  end
 
   def friends
     friends_array = friendships.map { |friendship| friendship.friend if friendship.confirmed }

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -6,40 +6,26 @@ class User < ApplicationRecord
 
   validates :name, presence: true, length: { maximum: 20 }
 
-  # has_many :friendships
-  has_many :sent_requests, -> { where confirmed: false }, class_name: 'Friendship', foreign_key: 'friend_id'
-  has_many :incoming_requests, -> { where confirmed: false }, class_name: 'Friendship', foreign_key: 'friend_id'
-  has_many :confirmed_friendships, -> { where confirmed: true }, class_name: 'Friendship', foreign_key: 'friend_id'
-
   has_many :posts
   has_many :comments, dependent: :destroy
   has_many :likes, dependent: :destroy
 
+  has_many :sent_requests, -> { where confirmed: false }, class_name: 'Friendship', foreign_key: 'user_id'
+  has_many :sent_friends, through: :sent_requests, source: :friend
+  has_many :incoming_requests, -> { where confirmed: false }, class_name: 'Friendship', foreign_key: 'friend_id'
+  has_many :incoming_friends, through: :incoming_requests, source: :user
+  has_many :confirmed_friendships, -> { where confirmed: true }, class_name: 'Friendship', foreign_key: 'user_id'
+  has_many :confirmed_friends, through: :confirmed_friendships, source: :friend
 
-  # def friends
-  #   friends_array = friendships.map { |friendship| friendship.friend if friendship.confirmed }
-  #   friends_array += inverse_friendships.map { |friendship| friendship.user if friendship.confirmed }
-  #   friends_array.compact
-  # end
+  def friendship_with?(other_user)
+    confirmed_friendships.find { | friendship | friendship if friendship.friend == other_user }
+  end
 
-  # def sent_requests
-  #   friendships.map { |friendship| friendship unless friendship.confirmed }.compact
-  # end
+  def sent_invite?(other_user)
+    sent_requests.find { | request | request if request.friend == other_user }
+  end
 
-  # def incoming_requests
-  #   inverse_friendships.map { |friendship| friendship unless friendship.confirmed }.compact
-  # end
-
-  # def friend?(user)
-  #   friendships.find { |friendship| friendship.friend == user if friendship.confirmed } ||
-  #     inverse_friendships.find { |friendship| friendship.user == user if friendship.confirmed }
-  # end
-
-  # def sent_invite(user)
-  #   friendships.find { |friendship| friendship.friend == user unless friendship.confirmed }
-  # end
-
-  # def incoming_invite(user)
-  #   inverse_friendships.find { |friendship| friendship.user == user unless friendship.confirmed }
-  # end
+  def incoming_invite?(other_user)
+    incoming_requests.find { | request | request if request.user == other_user }
+  end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -18,14 +18,14 @@ class User < ApplicationRecord
   has_many :confirmed_friends, through: :confirmed_friendships, source: :friend
 
   def friendship_with?(other_user)
-    confirmed_friendships.find { | friendship | friendship if friendship.friend == other_user }
+    confirmed_friendships.find { |friendship| friendship if friendship.friend == other_user }
   end
 
   def sent_invite?(other_user)
-    sent_requests.find { | request | request if request.friend == other_user }
+    sent_requests.find { |request| request if request.friend == other_user }
   end
 
   def incoming_invite?(other_user)
-    incoming_requests.find { | request | request if request.user == other_user }
+    incoming_requests.find { |request| request if request.user == other_user }
   end
 end

--- a/app/views/friendships/index.html.erb
+++ b/app/views/friendships/index.html.erb
@@ -28,12 +28,12 @@
       </div>
     <% end %>
     <br>
-    <h2> <%= "You have #{current_user.friends.count} friends"%> </h2>
+    <h2> <%= "You have #{@confirmed_friendships.count} friends"%> </h2>
     <hr>
-    <% @confirmed_friends.each do | friend | %>
+    <% @confirmed_friendships.each do | friendship | %>
       <br>
       <div>
-        <strong><%= link_to friend.name, user_path(friend) %></strong>
+        <strong><%= link_to friendship.friend.name, user_path(friendship.friend) %></strong>
       </div>
     <% end %>
   </div>

--- a/spec/features/friendship_requests_spec.rb
+++ b/spec/features/friendship_requests_spec.rb
@@ -21,7 +21,7 @@ feature 'friendship requests features', type: :feature do
     click_on 'Cancel Invite'
 
     expect(current_path).to eq('/friendships')
-    expect(page).to have_content('Friend request canceled/rejected/removed')
+    expect(page).to have_content('Friendship request canceled.')
   end
 
   scenario "a 'Reject Friend' button which rejects a friendship request" do
@@ -36,7 +36,7 @@ feature 'friendship requests features', type: :feature do
     click_on 'Reject Friend'
 
     expect(current_path).to eq('/friendships')
-    expect(page).to have_content('Friend request canceled/rejected/removed')
+    expect(page).to have_content('Friend request rejected.')
   end
 
   scenario "an 'Accept Friend' button which confirms a friendship" do
@@ -68,7 +68,7 @@ feature 'friendship requests features', type: :feature do
     click_on 'Remove Friend'
 
     expect(current_path).to eq('/friendships')
-    expect(page).to have_content('Friend request canceled/rejected/removed')
+    expect(page).to have_content('Friend removed.')
   end
 
   private

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -11,8 +11,12 @@ RSpec.describe User, type: :model do
   end
 
   describe 'associations' do
-    it { should have_many(:friendships) }
-    it { should have_many(:inverse_friendships) }
+    it { should have_many(:sent_requests) }
+    it { should have_many(:sent_friends) }
+    it { should have_many(:incoming_requests) }
+    it { should have_many(:incoming_friends) }
+    it { should have_many(:confirmed_friendships) }
+    it { should have_many(:confirmed_friends) }
     it { should have_many(:posts) }
     it { should have_many(:comments) }
     it { should have_many(:likes) }


### PR DESCRIPTION
In this PR,

I improved the Friendship feature by making the association of Friendship model with User more robust so that we can get all the data we need from the database with only one query, thus improving query performance. Whenever a user confirms an incoming friend request, it creates a reverse Friendship entry with `:confirmed` column set to `true`. This basically means querying only once when we need a list of a user's friends which reduces the performance of the query.